### PR TITLE
Better container split criteria

### DIFF
--- a/split-yarn-logs-per-container
+++ b/split-yarn-logs-per-container
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-awk '/Container:/{g++} { print $0 > "container-"g }' "$@"
+awk '/^Container: container_/{g++} { print $0 > "container-"g }' "$@"


### PR DESCRIPTION
This line caused a split, which shouldn't:
`16/04/20 09:13:10 INFO DefaultWriterContainer: Using user defined output committer class org.apache.parquet.hadoop.ParquetOutputCommitter`